### PR TITLE
3 subscriptions add delete action

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -18,6 +18,12 @@ class Api::V1::SubscriptionsController < ApplicationController
     end
   end
 
+  def destroy
+    customer = Customer.find(params[:customer_id])
+    subscription = Subscription.find(params[:id])
+    subscription.destroy!
+  end
+
   private
 
   def subscription_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     namespace :v1 do  
       resources :teas, only: [:show]
       resources :customers, only: [:show] do
-        resources :subscriptions, only: [:index, :create]
+        resources :subscriptions, only: [:index, :create, :destroy]
       end
     end
   end

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -65,4 +65,39 @@ RSpec.describe "Subscriptions", type: :request do
       expect{ Subscription.find(subscription.id) }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
+
+    describe "DELETE /customers/:customer_id/subscriptions/:id" do
+      it "SAD PATH: does NOT delete a subscription from the customer if the subscription id is not associated" do
+        tea = Tea.create!(title: "Green Tea", description: "Green tea is lighter than Black Tea.", temperature: 180, brew_time: 5)
+        customer = Customer.create!(first_name: "Jane", last_name: "Doe", email: "jane.doe@anyominous.com", address: "123 Main St")
+        subscription_params = { subscription: { title: "The Green Box", price: 9.99, status: "active", frequency: "monthly", tea_id: tea.id } }
+  
+        post api_v1_customer_subscriptions_path(customer), params: subscription_params
+  
+        subscription = Subscription.last
+        
+        expect(Subscription.count).to eq(1)
+
+        delete api_v1_customer_subscription_path(customer, id: subscription.id + 1)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "SAD PATH: does NOT delete a subscription from the customer if the customer is not associated" do
+        tea = Tea.create!(title: "Green Tea", description: "Green tea is lighter than Black Tea.", temperature: 180, brew_time: 5)
+        customer = Customer.create!(first_name: "Jane", last_name: "Doe", email: "jane.doe@anyominous.com", address: "123 Main St")
+        subscription_params = { subscription: { title: "The Green Box", price: 9.99, status: "active", frequency: "monthly", tea_id: tea.id } }
+  
+        post api_v1_customer_subscriptions_path(customer), params: subscription_params
+  
+        subscription = Subscription.last
+        
+        expect(Subscription.count).to eq(1)
+
+        wrong_customer = Customer.last.id + 1
+        delete api_v1_customer_subscription_path(customer_id: wrong_customer, id: subscription)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
 end

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe "Subscriptions", type: :request do
       expect(Subscription.count).to eq(1)
   
       delete api_v1_customer_subscription_path(customer, subscription)
-  
       expect(response).to be_successful
       expect(Subscription.count).to eq(0)
       expect{ Subscription.find(subscription.id) }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -46,4 +46,24 @@ RSpec.describe "Subscriptions", type: :request do
       expect(customer.subscriptions.count).to eq(0)
     end
   end
+
+  describe "DELETE /customers/:customer_id/subscriptions/:id" do
+    it "HAPPY PATH: deletes a subscription from the customer" do
+      tea = Tea.create!(title: "Green Tea", description: "Green tea is lighter than Black Tea.", temperature: 180, brew_time: 5)
+      customer = Customer.create!(first_name: "Jane", last_name: "Doe", email: "jane.doe@anyominous.com", address: "123 Main St")
+      subscription_params = { subscription: { title: "The Green Box", price: 9.99, status: "active", frequency: "monthly", tea_id: tea.id } }
+
+      post api_v1_customer_subscriptions_path(customer), params: subscription_params
+
+      subscription = Subscription.last
+      
+      expect(Subscription.count).to eq(1)
+  
+      delete api_v1_customer_subscription_path(customer, subscription)
+  
+      expect(response).to be_successful
+      expect(Subscription.count).to eq(0)
+      expect{ Subscription.find(subscription.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
 end


### PR DESCRIPTION
Add the delete action and two sad path tests.

Uses default error-handling, which could be made more robust in the future.